### PR TITLE
corrected compilation bugs on windows using visual 2010

### DIFF
--- a/GRT/ClassificationModules/ANBC/ANBC.cpp
+++ b/GRT/ClassificationModules/ANBC/ANBC.cpp
@@ -20,6 +20,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "ANBC.h"
 
+using namespace std;
+
 namespace GRT{
 
 //Register the ANBC module with the Classifier base class
@@ -230,7 +232,7 @@ bool ANBC::predict_(VectorDouble &inputVector){
         classLikelihoods[k] = classDistances[k];
         
         //If the distances are very far away then they could be -inf or nan so catch this so the sum still works
-        if( std::isinf(classLikelihoods[k]) || std::isnan(classLikelihoods[k]) ){
+        if( isinf(classLikelihoods[k]) || isnan(classLikelihoods[k]) ){
             classLikelihoods[k] = 0;
         }else{
             classLikelihoods[k] = exp( classLikelihoods[k] );

--- a/GRT/ClassificationModules/AdaBoost/AdaBoost.cpp
+++ b/GRT/ClassificationModules/AdaBoost/AdaBoost.cpp
@@ -20,6 +20,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "AdaBoost.h"
 
+using namespace std;
+
 namespace GRT{
 
 //Register the AdaBoost module with the Classifier base class
@@ -227,7 +229,7 @@ bool AdaBoost::train_(ClassificationData &trainingData){
             
             trainingLog << "PositiveClass: " << classLabels[classIter] << " Boosting Iter: " << t << " Best Classifier Index: " << bestClassifierIndex << " MinError: " << minError << " Alpha: " << alpha << endl;
             
-            if( std::isinf(alpha) ){ keepBoosting = false; trainingLog << "Alpha is INF. Stopping boosting for current class" << endl; }
+            if( isinf(alpha) ){ keepBoosting = false; trainingLog << "Alpha is INF. Stopping boosting for current class" << endl; }
             if( 0.5 - epsilon <= beta ){ keepBoosting = false; trainingLog << "Epsilon <= Beta. Stopping boosting for current class" << endl; }
             if( ++t >= numBoostingIterations ) keepBoosting = false;
 
@@ -263,7 +265,7 @@ bool AdaBoost::train_(ClassificationData &trainingData){
                 trainingLog << "Stopping boosting training at iteration : " << t-1 << " with an error of " << epsilon << endl;
                 if( t-1 == 0 ){
                     //Add the best weak classifier to the committee (we have to add it as this is the first iteration)
-                    if( std::isinf(alpha) ){ alpha = 1; } //If alpha is infinite then the first classifier got everything correct
+                    if( isinf(alpha) ){ alpha = 1; } //If alpha is infinite then the first classifier got everything correct
                     models[ classIter ].addClassifierToCommitee( weakClassifiers[bestClassifierIndex], alpha );
                 }
             }

--- a/GRT/ClassificationModules/DTW/DTW.cpp
+++ b/GRT/ClassificationModules/DTW/DTW.cpp
@@ -20,6 +20,8 @@
 
 #include "DTW.h"
 
+using namespace std;
+
 namespace GRT{
     
 //Register the DTW module with the Classifier base class
@@ -248,7 +250,7 @@ bool DTW::train_(TimeSeriesClassificationData &labelledTrainingData){
 
     //Flag that the models have been trained
 	trained = true;
-	averageTemplateLength = (UINT) averageTemplateLength/double(numTemplates);
+	averageTemplateLength = averageTemplateLength/numTemplates;
 
     //Recompute the null rejection thresholds
     recomputeNullRejectionThresholds();
@@ -609,7 +611,7 @@ double DTW::computeDistance(MatrixDouble &timeSeriesA,MatrixDouble &timeSeriesB,
     //Run the recursive search function to build the cost matrix
     double distance = sqrt( d(M-1,N-1,distanceMatrix,M,N) );
 
-    if( std::isinf(distance) || std::isnan(distance) ){
+    if( isinf(distance) || isnan(distance) ){
         warningLog << "DTW computeDistance(...) - Distance Matrix Values are INF!" << endl;
         return INFINITY;
     }
@@ -674,7 +676,7 @@ double DTW::d(int m,int n,MatrixDouble &distanceMatrix,const int M,const int N){
     //The following is based on Matlab code by Eamonn Keogh and Michael Pazzani
     
     //If this cell is NAN then it has already been flagged as unreachable
-    if( std::isnan( distanceMatrix[m][n] ) ){
+    if( isnan( distanceMatrix[m][n] ) ){
         return NAN;
     }
 

--- a/GRT/ClassificationModules/HMM/HiddenMarkovModel.cpp
+++ b/GRT/ClassificationModules/HMM/HiddenMarkovModel.cpp
@@ -20,6 +20,8 @@
 
 #include "HiddenMarkovModel.h"
 
+using namespace std;
+
 namespace GRT {
 
 //Default constructor
@@ -378,7 +380,7 @@ bool HiddenMarkovModel::forwardBackward(HMMTrainingObject &hmm,const vector<UINT
     for(t=0; t<T; t++) hmm.pk += log( hmm.c[t] );
     //hmm.pk = - hmm.pk; //We don't really need to minus here
     
-    if( std::isinf(hmm.pk) ){
+    if( isinf(hmm.pk) ){
         return false;
     }
     

--- a/GRT/ClassificationModules/KNN/KNN.cpp
+++ b/GRT/ClassificationModules/KNN/KNN.cpp
@@ -20,6 +20,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "KNN.h"
 
+using namespace std;
+
 namespace GRT{
     
 //Register the DTW module with the Classifier base class
@@ -278,11 +280,11 @@ bool KNN::train_(const ClassificationData &trainingData,const UINT K){
             if( trainingSigma[j] == 0 ){
                 warningLog << "TrainingSigma[ " << j << " ] is zero for a K value of " << K << endl;
             }
-            if( std::isnan( trainingMu[j] ) ){
+            if( isnan( trainingMu[j] ) ){
                 errorLog << "TrainingMu[ " << j << " ] is NAN for a K value of " << K << endl;
                 errorFound = true;
             }
-            if( std::isnan( trainingSigma[j] ) ){
+            if( isnan( trainingSigma[j] ) ){
                 errorLog << "TrainingSigma[ " << j << " ] is NAN for a K value of " << K << endl;
                 errorFound = true;
             }

--- a/GRT/ClusteringModules/SelfOrganizingMap/SelfOrganizingMap.cpp
+++ b/GRT/ClusteringModules/SelfOrganizingMap/SelfOrganizingMap.cpp
@@ -20,6 +20,8 @@
 
 #include "SelfOrganizingMap.h"
 
+using namespace std;
+
 namespace GRT{
     
 //Register the SelfOrganizingMap class with the Clusterer base class
@@ -267,7 +269,7 @@ bool SelfOrganizingMap::train_( MatrixDouble &data ){
             keepTraining = false;
         }
         
-        if( std::isinf( error ) ){
+        if( isinf( error ) ){
             errorLog << "train_(MatrixDouble &data) - Training failed! Error is NAN!" << endl;
             return false;
         }

--- a/GRT/CoreAlgorithms/BernoulliRBM/BernoulliRBM.cpp
+++ b/GRT/CoreAlgorithms/BernoulliRBM/BernoulliRBM.cpp
@@ -168,7 +168,9 @@ bool BernoulliRBM::train_(MatrixDouble &data){
         }
     }
     
-    const UINT numBatches = (UINT)ceil( numTrainingSamples/batchSize );
+    const UINT numBatches = static_cast<UINT>(
+        ceil( double(numTrainingSamples)/batchSize )
+    );
     
     //Setup the batch indexs
     vector< BatchIndexs > batchIndexs( numBatches );

--- a/GRT/CoreAlgorithms/ParticleFilter/ParticleFilter.h
+++ b/GRT/CoreAlgorithms/ParticleFilter/ParticleFilter.h
@@ -35,6 +35,8 @@
 #include "Particle.h"
 #include "../../Util/GRTCommon.h"
 
+using namespace std;
+
 namespace GRT{
 
 template<class PARTICLE,class SENSOR_DATA>
@@ -513,18 +515,18 @@ protected:
         for( iter = particles.begin(); iter != particles.end(); ++iter ){
             wNorm += iter->w;
             
-            if( std::isinf( iter->w ) ){
+            if( isinf( iter->w ) ){
                 numDeadParticles++;
             }
         }
         
-        if( std::isnan(wNorm) ){
+        if( isnan(wNorm) ){
             if( verbose )
                 warningLog << "WARNING: Weight norm is NAN!" << endl;
             return true;
         }
         
-        if( std::isinf(wNorm) ){
+        if( isinf(wNorm) ){
             if( verbose )
                 warningLog << "WARNING: Weight norm is INF!" << endl;
             return true;
@@ -564,7 +566,7 @@ protected:
                     for(unsigned int j=0; j<N; j++){
                         x[j] += iter->x[j];
                     }
-                    estimationLikelihood += std::isnan(iter->w) ? 0 : iter->w;
+                    estimationLikelihood += isnan(iter->w) ? 0 : iter->w;
                 }
                 
                 for(unsigned int j=0; j<N; j++){
@@ -584,7 +586,7 @@ protected:
                 }
                 
                 for( iter = particles.begin(); iter != particles.end(); ++iter ){
-                    estimationLikelihood += std::isnan(iter->w) ? 0 : iter->w;
+                    estimationLikelihood += isnan(iter->w) ? 0 : iter->w;
                 }
                 estimationLikelihood /= double(numParticles);
                 break;
@@ -609,7 +611,7 @@ protected:
                         for(unsigned int j=0; j<N; j++){
                             x[j] += iter->x[j] * iter->w;
                         }
-                        estimationLikelihood += std::isnan(iter->w) ? 0 : iter->w;
+                        estimationLikelihood += isnan(iter->w) ? 0 : iter->w;
                         sum += iter->w;
                         robustMeanParticleCounter++;
                     }
@@ -629,7 +631,7 @@ protected:
                     }
                 }
                 x = particles[bestIndex].x;
-                estimationLikelihood = std::isnan(particles[bestIndex].w) ? 0 : particles[bestIndex].w;
+                estimationLikelihood = isnan(particles[bestIndex].w) ? 0 : particles[bestIndex].w;
                 break;
             default:
                 errorLog << "ERROR: Unknown estimation mode!" << endl;

--- a/GRT/CoreModules/FeatureExtraction.cpp
+++ b/GRT/CoreModules/FeatureExtraction.cpp
@@ -116,7 +116,7 @@ bool FeatureExtraction::clear(){
     return true;
 }
    
-bool FeatureExtraction::saveModelToFile(const string filename) const{
+bool FeatureExtraction::saveModelToFile(string filename) const{
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::out);
@@ -130,7 +130,7 @@ bool FeatureExtraction::saveModelToFile(const string filename) const{
     return true;
 }
 
-bool FeatureExtraction::loadModelFromFile(const string filename){
+bool FeatureExtraction::loadModelFromFile(string filename){
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::in);

--- a/GRT/CoreModules/FeatureExtraction.h
+++ b/GRT/CoreModules/FeatureExtraction.h
@@ -95,7 +95,7 @@ public:
      @param const string filename: the filename to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool saveModelToFile(const string filename) const;
+    virtual bool saveModelToFile(string filename) const;
     
     /**
      This saves the feature extraction settings to a file.
@@ -104,7 +104,7 @@ public:
      @param fstream &file: a reference to the file to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool loadModelFromFile(const string filename);
+    virtual bool loadModelFromFile(string filename);
     
     /**
      This saves the feature extraction settings to a file.

--- a/GRT/CoreModules/MLBase.cpp
+++ b/GRT/CoreModules/MLBase.cpp
@@ -109,7 +109,7 @@ bool MLBase::predict(MatrixDouble inputMatrix){ return predict_( inputMatrix ); 
     
 bool MLBase::predict_(MatrixDouble &inputMatrix){ return false; }
 
-bool MLBase::MLBase::map(VectorDouble inputVector){ return map_( inputVector ); }
+bool MLBase::map(VectorDouble inputVector){ return map_( inputVector ); }
 
 bool MLBase::map_(VectorDouble &inputVector){ return false; }
 
@@ -128,7 +128,7 @@ bool MLBase::clear(){
 
 bool MLBase::print() const { return true; }
 
-bool MLBase::saveModelToFile(const string filename) const{
+bool MLBase::saveModelToFile(string filename) const{
     
     if( !trained ) return false;
     
@@ -146,7 +146,7 @@ bool MLBase::saveModelToFile(const string filename) const{
 
 bool MLBase::saveModelToFile(fstream &file) const { return false; }
 
-bool MLBase::loadModelFromFile(const string filename){
+bool MLBase::loadModelFromFile(string filename){
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::in);

--- a/GRT/CoreModules/MLBase.h
+++ b/GRT/CoreModules/MLBase.h
@@ -272,7 +272,7 @@ public:
      @param const string filename: the name of the file to save the model to
      @return returns true if the model was saved successfully, false otherwise
      */
-    virtual bool saveModelToFile(const string filename) const;
+    virtual bool saveModelToFile(string filename) const;
     
     /**
      This saves the trained model to a file.
@@ -289,7 +289,7 @@ public:
      @param const string filename: the name of the file to load the model from
      @return returns true if the model was loaded successfully, false otherwise
      */
-    virtual bool loadModelFromFile(const string filename);
+    virtual bool loadModelFromFile(string filename);
     
     /**
      This loads a trained model from a file.

--- a/GRT/CoreModules/PostProcessing.cpp
+++ b/GRT/CoreModules/PostProcessing.cpp
@@ -91,7 +91,7 @@ bool PostProcessing::init(){
     return true;
 }
     
-bool PostProcessing::saveModelToFile(const string filename) const{
+bool PostProcessing::saveModelToFile(string filename) const{
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::out);
@@ -105,7 +105,7 @@ bool PostProcessing::saveModelToFile(const string filename) const{
     return true;
 }
 
-bool PostProcessing::loadModelFromFile(const string filename){
+bool PostProcessing::loadModelFromFile(string filename){
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::in);

--- a/GRT/CoreModules/PostProcessing.h
+++ b/GRT/CoreModules/PostProcessing.h
@@ -87,7 +87,7 @@ public:
      @param const string filename: the filename to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool saveModelToFile(const string filename) const;
+    virtual bool saveModelToFile(string filename) const;
     
     /**
      This saves the post processing settings to a file.
@@ -96,7 +96,7 @@ public:
      @param fstream &file: a reference to the file to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool loadModelFromFile(const string filename);
+    virtual bool loadModelFromFile(string filename);
     
     /**
      This saves the post processing settings to a file.

--- a/GRT/CoreModules/PreProcessing.cpp
+++ b/GRT/CoreModules/PreProcessing.cpp
@@ -106,7 +106,7 @@ bool PreProcessing::init(){
     return true;
 }
 
-bool PreProcessing::saveModelToFile(const string filename) const{
+bool PreProcessing::saveModelToFile(string filename) const{
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::out);
@@ -120,7 +120,7 @@ bool PreProcessing::saveModelToFile(const string filename) const{
     return true;
 }
 
-bool PreProcessing::loadModelFromFile(const string filename){
+bool PreProcessing::loadModelFromFile(string filename){
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::in);

--- a/GRT/CoreModules/PreProcessing.h
+++ b/GRT/CoreModules/PreProcessing.h
@@ -94,7 +94,7 @@ public:
      @param const string filename: the filename to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool saveModelToFile(const string filename) const;
+    virtual bool saveModelToFile(string filename) const;
     
     /**
      This saves the preprocessing settings to a file.
@@ -103,7 +103,7 @@ public:
      @param fstream &file: a reference to the file to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool loadModelFromFile(const string filename);
+    virtual bool loadModelFromFile(string filename);
     
     /**
      This saves the preprocessing settings to a file.

--- a/GRT/FeatureExtractionModules/FFT/FFT.cpp
+++ b/GRT/FeatureExtractionModules/FFT/FFT.cpp
@@ -94,7 +94,7 @@ bool FFT::deepCopyFrom(const FeatureExtraction *featureExtraction){
     return false;
 }
     
-bool FFT::saveModelToFile(const string filename) const{
+bool FFT::saveModelToFile(string filename) const{
 
     std::fstream file;
     file.open(filename.c_str(), std::ios::out);
@@ -108,7 +108,7 @@ bool FFT::saveModelToFile(const string filename) const{
     return true;
 }
 
-bool FFT::loadModelFromFile(const string filename){
+bool FFT::loadModelFromFile(string filename){
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::in);

--- a/GRT/FeatureExtractionModules/FFT/FFT.h
+++ b/GRT/FeatureExtractionModules/FFT/FFT.h
@@ -126,7 +126,7 @@ public:
      @param const string filename: the filename to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool saveModelToFile(const string filename) const;
+    virtual bool saveModelToFile(string filename) const;
     
     /**
      This saves the feature extraction settings to a file.
@@ -134,7 +134,7 @@ public:
      @param fstream &file: a reference to the file to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool loadModelFromFile(const string filename);
+    virtual bool loadModelFromFile(string filename);
     
     /**
      This saves the feature extraction settings to a file.

--- a/GRT/FeatureExtractionModules/FFT/FFTFeatures.cpp
+++ b/GRT/FeatureExtractionModules/FFT/FFTFeatures.cpp
@@ -94,7 +94,7 @@ bool FFTFeatures::deepCopyFrom(const FeatureExtraction *featureExtraction){
     return false;
 }
     
-bool FFTFeatures::saveModelToFile(const string filename) const{
+bool FFTFeatures::saveModelToFile(string filename) const{
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::out);
@@ -108,7 +108,7 @@ bool FFTFeatures::saveModelToFile(const string filename) const{
     return true;
 }
 
-bool FFTFeatures::loadModelFromFile(const string filename){
+bool FFTFeatures::loadModelFromFile(string filename){
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::in);

--- a/GRT/FeatureExtractionModules/FFT/FFTFeatures.h
+++ b/GRT/FeatureExtractionModules/FFT/FFTFeatures.h
@@ -105,7 +105,7 @@ public:
      @param const string filename: the filename to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool saveModelToFile(const string filename) const;
+    virtual bool saveModelToFile(string filename) const;
     
     /**
      This saves the feature extraction settings to a file.
@@ -113,7 +113,7 @@ public:
      @param fstream &file: a reference to the file to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool loadModelFromFile(const string filename);
+    virtual bool loadModelFromFile(string filename);
     
     /**
      This saves the feature extraction settings to a file.

--- a/GRT/FeatureExtractionModules/KMeansFeatures/KMeansFeatures.cpp
+++ b/GRT/FeatureExtractionModules/KMeansFeatures/KMeansFeatures.cpp
@@ -124,7 +124,7 @@ bool KMeansFeatures::reset(){
     return true;
 }
     
-bool KMeansFeatures::saveModelToFile(const string filename) const{
+bool KMeansFeatures::saveModelToFile(string filename) const{
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::out);
@@ -138,7 +138,7 @@ bool KMeansFeatures::saveModelToFile(const string filename) const{
     return true;
 }
 
-bool KMeansFeatures::loadModelFromFile(const string filename){
+bool KMeansFeatures::loadModelFromFile(string filename){
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::in);

--- a/GRT/FeatureExtractionModules/KMeansFeatures/KMeansFeatures.h
+++ b/GRT/FeatureExtractionModules/KMeansFeatures/KMeansFeatures.h
@@ -103,7 +103,7 @@ public:
      @param const string filename: the filename to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool saveModelToFile(const string filename) const;
+    virtual bool saveModelToFile(string filename) const;
     
     /**
      This saves the feature extraction settings to a file.
@@ -111,7 +111,7 @@ public:
      @param fstream &file: a reference to the file to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool loadModelFromFile(const string filename);
+    virtual bool loadModelFromFile(string filename);
     
     /**
      This saves the feature extraction settings to a file.

--- a/GRT/FeatureExtractionModules/KMeansQuantizer/KMeansQuantizer.cpp
+++ b/GRT/FeatureExtractionModules/KMeansQuantizer/KMeansQuantizer.cpp
@@ -111,7 +111,7 @@ bool KMeansQuantizer::clear(){
     return true;
 }
     
-bool KMeansQuantizer::saveModelToFile(const string filename) const{
+bool KMeansQuantizer::saveModelToFile(string filename) const{
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::out);
@@ -125,7 +125,7 @@ bool KMeansQuantizer::saveModelToFile(const string filename) const{
     return true;
 }
 
-bool KMeansQuantizer::loadModelFromFile(const string filename){
+bool KMeansQuantizer::loadModelFromFile(string filename){
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::in);

--- a/GRT/FeatureExtractionModules/KMeansQuantizer/KMeansQuantizer.h
+++ b/GRT/FeatureExtractionModules/KMeansQuantizer/KMeansQuantizer.h
@@ -115,7 +115,7 @@ public:
      @param const string filename: the filename to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool saveModelToFile(const string filename) const;
+    virtual bool saveModelToFile(string filename) const;
     
     /**
      This saves the feature extraction settings to a file.
@@ -123,7 +123,7 @@ public:
      @param fstream &file: a reference to the file to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool loadModelFromFile(const string filename);
+    virtual bool loadModelFromFile(string filename);
     
     /**
      This saves the feature extraction settings to a file.

--- a/GRT/FeatureExtractionModules/MovementIndex/MovementIndex.cpp
+++ b/GRT/FeatureExtractionModules/MovementIndex/MovementIndex.cpp
@@ -103,7 +103,7 @@ bool MovementIndex::reset(){
     return false;
 }
     
-bool MovementIndex::saveModelToFile(const string filename) const{
+bool MovementIndex::saveModelToFile(string filename) const{
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::out);
@@ -117,7 +117,7 @@ bool MovementIndex::saveModelToFile(const string filename) const{
     return true;
 }
 
-bool MovementIndex::loadModelFromFile(const string filename){
+bool MovementIndex::loadModelFromFile(string filename){
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::in);

--- a/GRT/FeatureExtractionModules/MovementIndex/MovementIndex.h
+++ b/GRT/FeatureExtractionModules/MovementIndex/MovementIndex.h
@@ -103,7 +103,7 @@ public:
      @param const string filename: the filename to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool saveModelToFile(const string filename) const;
+    virtual bool saveModelToFile(string filename) const;
     
     /**
      This saves the feature extraction settings to a file.
@@ -111,7 +111,7 @@ public:
      @param fstream &file: a reference to the file to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool loadModelFromFile(const string filename);
+    virtual bool loadModelFromFile(string filename);
     
     /**
      This saves the feature extraction settings to a file.

--- a/GRT/FeatureExtractionModules/MovementTrajectoryFeatures/MovementTrajectoryFeatures.cpp
+++ b/GRT/FeatureExtractionModules/MovementTrajectoryFeatures/MovementTrajectoryFeatures.cpp
@@ -110,7 +110,7 @@ bool MovementTrajectoryFeatures::reset(){
     return false;
 }
     
-bool MovementTrajectoryFeatures::saveModelToFile(const string filename) const{
+bool MovementTrajectoryFeatures::saveModelToFile(string filename) const{
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::out);
@@ -124,7 +124,7 @@ bool MovementTrajectoryFeatures::saveModelToFile(const string filename) const{
     return true;
 }
 
-bool MovementTrajectoryFeatures::loadModelFromFile(const string filename){
+bool MovementTrajectoryFeatures::loadModelFromFile(string filename){
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::in);

--- a/GRT/FeatureExtractionModules/MovementTrajectoryFeatures/MovementTrajectoryFeatures.h
+++ b/GRT/FeatureExtractionModules/MovementTrajectoryFeatures/MovementTrajectoryFeatures.h
@@ -106,7 +106,7 @@ public:
      @param const string filename: the filename to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool saveModelToFile(const string filename) const;
+    virtual bool saveModelToFile(string filename) const;
     
     /**
      This saves the feature extraction settings to a file.
@@ -114,7 +114,7 @@ public:
      @param fstream &file: a reference to the file to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool loadModelFromFile(const string filename);
+    virtual bool loadModelFromFile(string filename);
     
     /**
      This saves the feature extraction settings to a file.

--- a/GRT/FeatureExtractionModules/RBMQuantizer/RBMQuantizer.cpp
+++ b/GRT/FeatureExtractionModules/RBMQuantizer/RBMQuantizer.cpp
@@ -111,7 +111,7 @@ bool RBMQuantizer::clear(){
     return true;
 }
     
-bool RBMQuantizer::saveModelToFile(const string filename) const{
+bool RBMQuantizer::saveModelToFile(string filename) const{
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::out);
@@ -125,7 +125,7 @@ bool RBMQuantizer::saveModelToFile(const string filename) const{
     return true;
 }
 
-bool RBMQuantizer::loadModelFromFile(const string filename){
+bool RBMQuantizer::loadModelFromFile(string filename){
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::in);
@@ -322,7 +322,7 @@ UINT RBMQuantizer::getNumClusters() const{
 }
 
 UINT RBMQuantizer::getQuantizedValue() const {
-    return (trained ? featureVector[0] : 0);
+    return (trained ? static_cast<UINT>(featureVector[0]) : 0);
 }
 
 VectorDouble RBMQuantizer::getQuantizationDistances() const{

--- a/GRT/FeatureExtractionModules/RBMQuantizer/RBMQuantizer.h
+++ b/GRT/FeatureExtractionModules/RBMQuantizer/RBMQuantizer.h
@@ -116,7 +116,7 @@ public:
      @param const string filename: the filename to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool saveModelToFile(const string filename) const;
+    virtual bool saveModelToFile(string filename) const;
     
     /**
      This saves the feature extraction settings to a file.
@@ -124,7 +124,7 @@ public:
      @param fstream &file: a reference to the file to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool loadModelFromFile(const string filename);
+    virtual bool loadModelFromFile(string filename);
     
     /**
      This saves the feature extraction settings to a file.

--- a/GRT/FeatureExtractionModules/SOMQuantizer/SOMQuantizer.cpp
+++ b/GRT/FeatureExtractionModules/SOMQuantizer/SOMQuantizer.cpp
@@ -115,7 +115,7 @@ bool SOMQuantizer::clear(){
     return true;
 }
     
-bool SOMQuantizer::saveModelToFile(const string filename) const{
+bool SOMQuantizer::saveModelToFile(string filename) const{
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::out);
@@ -129,7 +129,7 @@ bool SOMQuantizer::saveModelToFile(const string filename) const{
     return true;
 }
 
-bool SOMQuantizer::loadModelFromFile(const string filename){
+bool SOMQuantizer::loadModelFromFile(string filename){
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::in);
@@ -334,7 +334,7 @@ UINT SOMQuantizer::getNumClusters() const{
 }
 
 UINT SOMQuantizer::getQuantizedValue() const {
-    return (trained ? featureVector[0] : 0);
+    return (trained ? static_cast<UINT>(featureVector[0]) : 0);
 }
 
 VectorDouble SOMQuantizer::getQuantizationDistances() const{

--- a/GRT/FeatureExtractionModules/SOMQuantizer/SOMQuantizer.h
+++ b/GRT/FeatureExtractionModules/SOMQuantizer/SOMQuantizer.h
@@ -115,7 +115,7 @@ public:
      @param const string filename: the filename to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool saveModelToFile(const string filename) const;
+    virtual bool saveModelToFile(string filename) const;
     
     /**
      This saves the feature extraction settings to a file.
@@ -123,7 +123,7 @@ public:
      @param fstream &file: a reference to the file to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool loadModelFromFile(const string filename);
+    virtual bool loadModelFromFile(string filename);
     
     /**
      This saves the feature extraction settings to a file.

--- a/GRT/FeatureExtractionModules/TimeDomainFeatures/TimeDomainFeatures.cpp
+++ b/GRT/FeatureExtractionModules/TimeDomainFeatures/TimeDomainFeatures.cpp
@@ -110,7 +110,7 @@ bool TimeDomainFeatures::reset(){
     return false;
 }
     
-bool TimeDomainFeatures::saveModelToFile(const string filename) const{
+bool TimeDomainFeatures::saveModelToFile(string filename) const{
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::out);
@@ -124,7 +124,7 @@ bool TimeDomainFeatures::saveModelToFile(const string filename) const{
     return true;
 }
 
-bool TimeDomainFeatures::loadModelFromFile(const string filename){
+bool TimeDomainFeatures::loadModelFromFile(string filename){
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::in);

--- a/GRT/FeatureExtractionModules/TimeDomainFeatures/TimeDomainFeatures.h
+++ b/GRT/FeatureExtractionModules/TimeDomainFeatures/TimeDomainFeatures.h
@@ -95,7 +95,7 @@ public:
      @param const string filename: the filename to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool saveModelToFile(const string filename) const;
+    virtual bool saveModelToFile(string filename) const;
     
     /**
      This saves the feature extraction settings to a file.
@@ -103,7 +103,7 @@ public:
      @param fstream &file: a reference to the file to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool loadModelFromFile(const string filename);
+    virtual bool loadModelFromFile(string filename);
     
     /**
      This saves the feature extraction settings to a file.

--- a/GRT/FeatureExtractionModules/TimeseriesBuffer/TimeseriesBuffer.cpp
+++ b/GRT/FeatureExtractionModules/TimeseriesBuffer/TimeseriesBuffer.cpp
@@ -103,7 +103,7 @@ bool TimeseriesBuffer::reset(){
     return false;
 }
     
-bool TimeseriesBuffer::saveModelToFile(const string filename) const{
+bool TimeseriesBuffer::saveModelToFile(string filename) const{
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::out);
@@ -117,7 +117,7 @@ bool TimeseriesBuffer::saveModelToFile(const string filename) const{
     return true;
 }
 
-bool TimeseriesBuffer::loadModelFromFile(const string filename){
+bool TimeseriesBuffer::loadModelFromFile(string filename){
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::in);

--- a/GRT/FeatureExtractionModules/TimeseriesBuffer/TimeseriesBuffer.h
+++ b/GRT/FeatureExtractionModules/TimeseriesBuffer/TimeseriesBuffer.h
@@ -98,7 +98,7 @@ public:
      @param const string filename: the filename to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool saveModelToFile(const string filename) const;
+    virtual bool saveModelToFile(string filename) const;
     
     /**
      This saves the feature extraction settings to a file.
@@ -106,7 +106,7 @@ public:
      @param fstream &file: a reference to the file to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool loadModelFromFile(const string filename);
+    virtual bool loadModelFromFile(string filename);
     
     /**
      This saves the feature extraction settings to a file.

--- a/GRT/FeatureExtractionModules/ZeroCrossingCounter/ZeroCrossingCounter.cpp
+++ b/GRT/FeatureExtractionModules/ZeroCrossingCounter/ZeroCrossingCounter.cpp
@@ -105,7 +105,7 @@ bool ZeroCrossingCounter::reset(){
     return false;
 }
     
-bool ZeroCrossingCounter::saveModelToFile(const string filename) const{
+bool ZeroCrossingCounter::saveModelToFile(string filename) const{
 
     std::fstream file;
     file.open(filename.c_str(), std::ios::out);
@@ -119,7 +119,7 @@ bool ZeroCrossingCounter::saveModelToFile(const string filename) const{
     return true;
 }
 
-bool ZeroCrossingCounter::loadModelFromFile(const string filename){
+bool ZeroCrossingCounter::loadModelFromFile(string filename){
     
     std::fstream file;
     file.open(filename.c_str(), std::ios::in);

--- a/GRT/FeatureExtractionModules/ZeroCrossingCounter/ZeroCrossingCounter.h
+++ b/GRT/FeatureExtractionModules/ZeroCrossingCounter/ZeroCrossingCounter.h
@@ -115,7 +115,7 @@ public:
      @param const string filename: the filename to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool saveModelToFile(const string filename) const;
+    virtual bool saveModelToFile(string filename) const;
     
     /**
      This saves the feature extraction settings to a file.
@@ -123,7 +123,7 @@ public:
      @param fstream &file: a reference to the file to save the settings to
      @return returns true if the settings were saved successfully, false otherwise
      */
-    virtual bool loadModelFromFile(const string filename);
+    virtual bool loadModelFromFile(string filename);
     
     /**
      This saves the feature extraction settings to a file.

--- a/GRT/PostProcessingModules/ClassLabelTimeoutFilter.cpp
+++ b/GRT/PostProcessingModules/ClassLabelTimeoutFilter.cpp
@@ -25,7 +25,7 @@ namespace GRT{
 //Register the ClassLabelTimeoutFilter module with the PostProcessing base class
 RegisterPostProcessingModule< ClassLabelTimeoutFilter > ClassLabelTimeoutFilter::registerModule("ClassLabelTimeoutFilter");
     
-ClassLabelTimeoutFilter::ClassLabelTimeoutFilter(double timeoutDuration,UINT filterMode){
+ClassLabelTimeoutFilter::ClassLabelTimeoutFilter(unsigned long timeoutDuration,UINT filterMode){
     classType = "ClassLabelTimeoutFilter";
     postProcessingType = classType;
     postProcessingInputMode = INPUT_MODE_PREDICTED_CLASS_LABEL;
@@ -122,7 +122,7 @@ bool ClassLabelTimeoutFilter::reset(){
     return true;
 }
     
-bool ClassLabelTimeoutFilter::init(double timeoutDuration,UINT filterMode){
+bool ClassLabelTimeoutFilter::init(unsigned long timeoutDuration,UINT filterMode){
 
     initialized = false;
     
@@ -338,7 +338,7 @@ bool ClassLabelTimeoutFilter::loadModelFromFile(fstream &file){
     return init(timeoutDuration,filterMode);
 }
     
-bool ClassLabelTimeoutFilter::setTimeoutDuration(double timeoutDuration){
+bool ClassLabelTimeoutFilter::setTimeoutDuration(unsigned long timeoutDuration){
     if( timeoutDuration < 0 ) return false;
     this->timeoutDuration = timeoutDuration;
     if( initialized ){

--- a/GRT/PostProcessingModules/ClassLabelTimeoutFilter.h
+++ b/GRT/PostProcessingModules/ClassLabelTimeoutFilter.h
@@ -45,13 +45,13 @@ public:
     ClassLabelAndTimer(){
         classLabel = 0;
     }
-    ClassLabelAndTimer(UINT classLabel,double timeoutDuration){
+    ClassLabelAndTimer(UINT classLabel,unsigned long timeoutDuration){
         this->classLabel = classLabel;
         timer.start(timeoutDuration);
     }
     
     //Setters
-    bool set(UINT classLabel,double timeoutDuration){
+    bool set(UINT classLabel,unsigned long timeoutDuration){
         if( classLabel > 0 && timeoutDuration > 0 ){
             this->classLabel = classLabel;
             timer.start(timeoutDuration);
@@ -63,7 +63,7 @@ public:
     //Getters
     UINT getClassLabel(){ return classLabel; }
     bool timerReached(){ return timer.timerReached(); }
-    double getRemainingTime(){ return timer.getMilliSeconds(); }
+    unsigned long getRemainingTime(){ return timer.getMilliSeconds(); }
     
 protected:
     UINT classLabel;
@@ -91,10 +91,10 @@ public:
      mode was activated with the class label of 1, and then class 2 was input into the class label filter, then the
      debounce mode would be reset to class 2, even if the timeoutDuration for class 1 had not expired.
      
-     @param double timeoutDuration: sets the timeoutDuration value (in milliseconds). Default value timeoutDuration=1000
+     @param unsigned long timeoutDuration: sets the timeoutDuration value (in milliseconds). Default value timeoutDuration=1000
      @param UINT filterMode: sets the filterMode parameter. Default value filterMode=ALL_CLASS_LABELS
      */
-    ClassLabelTimeoutFilter(double timeoutDuration = 1000,UINT filterMode = ALL_CLASS_LABELS);
+    ClassLabelTimeoutFilter(unsigned long timeoutDuration = 1000,UINT filterMode = ALL_CLASS_LABELS);
     
     /**
      Copy Constructor.
@@ -190,7 +190,7 @@ public:
      @param UINT filterMode: sets the filterMode parameter
      @return returns true if the ClassLabelTimeoutFilter was initialized, false otherwise
      */
-    bool init(double timeoutDuration,UINT filterMode = ALL_CLASS_LABELS); 
+    bool init(unsigned long timeoutDuration,UINT filterMode = ALL_CLASS_LABELS); 
     
     /**
      This is the main filter function which filters the input predictedClassLabel.
@@ -226,7 +226,7 @@ public:
      @param double timeoutDuration: the new timeoutDuration parameter
      @return returns true if the timeoutDuration parameter was updated, false otherwise
      */
-    bool setTimeoutDuration(double timeoutDuration);
+    bool setTimeoutDuration(unsigned long timeoutDuration);
     
     /**
      Sets the filterMode parameter, must be a value greater than 0.
@@ -254,7 +254,7 @@ public:
 protected:
     UINT filteredClassLabel;
     UINT filterMode;
-    double timeoutDuration;
+    unsigned long timeoutDuration;
     vector< ClassLabelAndTimer > classLabelTimers;
     
     static RegisterPostProcessingModule< ClassLabelTimeoutFilter > registerModule;

--- a/GRT/RegressionModules/LinearRegression/LinearRegression.cpp
+++ b/GRT/RegressionModules/LinearRegression/LinearRegression.cpp
@@ -20,6 +20,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "LinearRegression.h"
 
+using namespace std;
+
 namespace GRT{
 
 //Register the LinearRegression module with the Classifier base class
@@ -167,7 +169,7 @@ bool LinearRegression::train_(RegressionData &trainingData){
             keepTraining = false;
         }
         
-        if( std::isinf( totalSquaredTrainingError ) || std::isnan( totalSquaredTrainingError ) ){
+        if( isinf( totalSquaredTrainingError ) || isnan( totalSquaredTrainingError ) ){
             errorLog << "train_(RegressionData &trainingData) - Training failed! Total squared training error is NAN. If scaling is not enabled then you should try to scale your data and see if this solves the issue." << endl;
             return false;
         }

--- a/GRT/RegressionModules/LogisticRegression/LogisticRegression.cpp
+++ b/GRT/RegressionModules/LogisticRegression/LogisticRegression.cpp
@@ -20,6 +20,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "LogisticRegression.h"
 
+using namespace std;
+
 namespace GRT{
 
 //Register the LogisticRegression module with the Classifier base class
@@ -171,7 +173,7 @@ bool LogisticRegression::train_(RegressionData &trainingData){
             keepTraining = false;
         }
         
-        if( std::isinf( totalSquaredTrainingError ) || std::isnan( totalSquaredTrainingError ) ){
+        if( isinf( totalSquaredTrainingError ) || isnan( totalSquaredTrainingError ) ){
             errorLog << "train_(RegressionData &trainingData) - Training failed! Total squared error is NAN. If scaling is not enabled then you should try to scale your data and see if this solves the issue." << endl;
             return false;
         }

--- a/GRT/Util/EigenvalueDecomposition.h
+++ b/GRT/Util/EigenvalueDecomposition.h
@@ -101,14 +101,17 @@ protected:
       Complex scalar division.
      */
     void cdiv(double xr, double xi, double yr, double yi);
-    
-    inline double findMax(const double &a,const double &b){
+
+    template< class T >
+    inline T findMax(const T &a,const T &b){
         return (a > b ? a : b);
     }
-    inline double findMin(const double &a,const double &b){
+    template< class T >
+    inline T findMin(const T &a,const T &b){
         return (a < b ? a : b);
     }
-    inline double hypot(const double &a,const double &b){
+    template< class T >
+    inline T hypot(const T &a,const T &b){
         return sqrt( (a*a)+(b*b) );
     }
     

--- a/GRT/Util/GRTCommon.h
+++ b/GRT/Util/GRTCommon.h
@@ -89,7 +89,7 @@ inline double antilog(const double &x){ return exp( x ); }
 
 	//isnan is not defined on Visual Studio so define it here
 	#ifndef isnan
-		#define isnan(x) x != x
+		#define isnan(x) (x != x)
 	#endif
 
 	//isnan is not defined on Visual Studio so define it here

--- a/GRT/Util/TrainingDataRecordingTimer.cpp
+++ b/GRT/Util/TrainingDataRecordingTimer.cpp
@@ -49,7 +49,7 @@ TrainingDataRecordingTimer& TrainingDataRecordingTimer::operator=(const Training
 	return *this;
 }
     
-bool TrainingDataRecordingTimer::startRecording(double prepTime,double recordTime){
+bool TrainingDataRecordingTimer::startRecording(unsigned long prepTime,unsigned long recordTime){
     this->prepTime = prepTime;
     this->recordTime = recordTime;
    

--- a/GRT/Util/TrainingDataRecordingTimer.h
+++ b/GRT/Util/TrainingDataRecordingTimer.h
@@ -61,7 +61,7 @@ public:
 	*/
 	TrainingDataRecordingTimer& operator= (const TrainingDataRecordingTimer &rhs);
     
-    bool startRecording(double prepTime,double recordTime);
+    bool startRecording(unsigned long prepTime,unsigned long recordTime);
     
     bool stopRecording();
     
@@ -77,8 +77,8 @@ public:
 
 protected:
     UINT recordingMode;
-    double prepTime;
-    double recordTime;
+    unsigned long prepTime;
+    unsigned long recordTime;
     Timer trainingTimer;
     
     


### PR DESCRIPTION
Compilation bug and warning correction:
- isinf() and isnan() were defined as macros for windows build in GRTCommon.h, but used prefixed with "std::": I removed the prefixes and added "using namespace std;" at the beginning of the file.
- GRT::MLBase::saveModelToFile() and GRT::MLBase::loadModelToFile() were both declared with a const string parameter, but some of the overloadings in the derived classes were declared with non-const parameter: because the parameter was a copy and not a reference, I chose to remove the const qualifier.
- I corrected some other issues about double to uint conversion.
