### PR TITLE
Windows MSVC compiler

### DIFF
--- a/GRT/Util/GRTCommon.h
+++ b/GRT/Util/GRTCommon.h
@@ -70,4 +70,10 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "FileParser.h"
 #include "ObserverManager.h"
 
+#if _MSC_VER >= 1600
+    inline double round( double d ) {
+        return floor( d + 0.5 );
+    }
+#endif
+
 #endif //GRT_COMMON_HEADER

--- a/gui/GRT/GRT.pro
+++ b/gui/GRT/GRT.pro
@@ -91,8 +91,8 @@ unix:!macx{
 win32{
  #Add the custom GRT and boost paths
  INCLUDEPATH += C:\grt
- INCLUDEPATH += C:\boost\boost_1_54_0
- LIBS += -LC:\boost\boost_1_54_0\stage\lib
+ INCLUDEPATH += C:\boost_1_57_0
+ LIBS += -Lc:\boost_1_57_0\lib32-msvc-11.0\
 
  #Add the base oscpack directory
  INCLUDEPATH += OSC/oscpack/include
@@ -105,10 +105,10 @@ win32{
  LIBS += -lwinmm
 
  #Include the boost libraries (if you are using a different version of boost, then you will need to edit these)
- LIBS += -lboost_thread-mgw48-mt-1_54
- LIBS += -lboost_date_time-mgw48-mt-1_54
- LIBS += -lboost_system-mgw48-mt-1_54
- LIBS += -lboost_chrono-mgw48-mt-1_54
+ LIBS += -lboost_thread-vc110-mt-1_57
+ LIBS += -lboost_date_time-vc110-mt-1_57
+ LIBS += -lboost_system-vc110-mt-1_57
+ LIBS += -lboost_chrono-vc110-mt-1_57
 }
 
 #If USE_GRT_LIB is defined, then we add the prebuilt GRT lib

--- a/gui/GRT/OSC/OSCServer.h
+++ b/gui/GRT/OSC/OSCServer.h
@@ -8,7 +8,11 @@
 
 #include <boost/thread.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include "OSC/OSCMessage.h"
+#if _MSC_VER >= 1600
+    #include "OSCMessage.h"
+#else
+    #include "OSC/OSCMessage.h"
+#endif
 #include <queue>
 
 #define STRING_TO_QSTRING(x) QString(x)

--- a/gui/GRT/mainwindow.cpp
+++ b/gui/GRT/mainwindow.cpp
@@ -2813,7 +2813,7 @@ void MainWindow::updateClassifierView(const int viewIndex){
             randomForests.enableNullRejection( ui->pipelineTool_enableNullRejection->isChecked() );
             randomForests.setNullRejectionCoeff( ui->pipelineTool_nullRejectionCoeff->value() );
             randomForests.setForestSize( ui->pipelineTool_randomForests_numTrees->value() );
-            randomForests.setNumRandomSpilts( ui->pipelineTool_randomForests_numSpiltingSteps->value() );
+            randomForests.setNumRandomSplits( ui->pipelineTool_randomForests_numSpiltingSteps->value() );
             randomForests.setMaxDepth( ui->pipelineTool_randomForests_maxDepth->value() );
             randomForests.setMinNumSamplesPerNode( ui->pipelineTool_randomForests_minSamplesPerNode->value() );
             core.setClassifier( randomForests );

--- a/gui/GRT/timeseriesgraph.cpp
+++ b/gui/GRT/timeseriesgraph.cpp
@@ -4,6 +4,7 @@
 double TimeseriesGraph::maximumGraphRefreshFramerate = 0.2;
 bool TimeseriesGraph::setMaximumGraphRefreshRate(const double framerate){
     maximumGraphRefreshFramerate = framerate;
+    return true;
 }
 
 TimeseriesGraph::TimeseriesGraph(QWidget *parent) :

--- a/gui/README.md
+++ b/gui/README.md
@@ -16,11 +16,11 @@
     python build-release_OSNAME.py
 	
 	
-####Building on Windows
+####Building on Windows (Visual Studio 2012 Express)
 
-1. Download and install QTCreator: http://qt-project.org/ (ensure you include the MinGW compiler)
+1. Download and install Qt 5.4.0 for Windows 32-bit (VS 2012, OpenGL, 643 MB) : http://www.qt.io/download-open-source/ 
 2. Open Qt and try and build and run one of the examples to ensure it is installed correctly)
-3. Download boost 1_54_0 (newer versions of boost are much harder to compile on Windows): http://www.boost.org/users/history/
+3. Download boost 1_57_0 (msvc-11_32 for Visual Studio 2012, msvc-12 for Visual Studio 2013): http://sourceforge.net/projects/boost/files/boost-binaries/1.57.0/
 4. Install boost (see notes below)
 5. Copy the main GRT project folder to: C:\grt
 6. Open the main GRT qt file (GRT.pro) using QtCreator (Qt: File -> Open File or Project)
@@ -29,9 +29,9 @@
 8. Build the project
 9. If the build is successful, press Run to launch the GUI
 
-Note, so far this has only been tested on Windows 7 with Qt Creator 5.3 and boost 1_54_0.
+Note, so far this has only been tested on Windows 7 with Qt 5.4.0 for Windows 32-bit (VS 2012, OpenGL) and boost 1_57_0 and Visual Studio 2012 Express.
 
-####Building Boost on Windows
+#### [OPTIONAL] Building Boost on Windows
 Building boost on Windows can be a major pain, this is the best options I've found so far:
 
 1. Download boost 1_54_0 (the steps below do not work on newer versions of boost): http://www.boost.org/users/history/


### PR DESCRIPTION
On Windows it's much easier to use MSVC compiler from Visual Studio than MingW compiler. Using Visual Studio 2012 Express for example we can just download the latest Boost binary. There's no need to compile Boost anymore.