### PR TITLE
Disable tool install if set in config

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -313,12 +313,14 @@ if( BUILD_TOOLS )
         #Link the tools against the GRT library
         target_link_libraries(${EXE} ${GRT_LIB_NAME})
 
-        install(
-            TARGETS ${EXE}
-            RUNTIME DESTINATION bin
-            LIBRARY DESTINATION lib
-            ARCHIVE DESTINATION lib
-        )
+		if(NOT EXCLUDE_FROM_INSTALL)
+			install(
+				TARGETS ${EXE}
+				RUNTIME DESTINATION bin
+				LIBRARY DESTINATION lib
+				ARCHIVE DESTINATION lib
+			)
+		endif()
     endforeach()
 
 endif() #BUILD_TOOLS

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -313,14 +313,14 @@ if( BUILD_TOOLS )
         #Link the tools against the GRT library
         target_link_libraries(${EXE} ${GRT_LIB_NAME})
 
-		if(NOT EXCLUDE_FROM_INSTALL)
-			install(
-				TARGETS ${EXE}
-				RUNTIME DESTINATION bin
-				LIBRARY DESTINATION lib
-				ARCHIVE DESTINATION lib
-			)
-		endif()
+        if(NOT EXCLUDE_FROM_INSTALL)
+            install(
+                TARGETS ${EXE}
+                RUNTIME DESTINATION bin
+                LIBRARY DESTINATION lib
+                ARCHIVE DESTINATION lib
+            )
+        endif()
     endforeach()
 
 endif() #BUILD_TOOLS


### PR DESCRIPTION
Added support for the EXCLUDE_FROM_INSTALL option for new tools targets.

In particular, this is useful when GRT is included as part of another cmake project using recursive CMakeFiles.txt inclusions.