### PR TITLE
Added missing include

### DIFF
--- a/GRT/CoreAlgorithms/GridSearch/GridSearch.h
+++ b/GRT/CoreAlgorithms/GridSearch/GridSearch.h
@@ -31,6 +31,8 @@
 #include "../../CoreModules/MLBase.h"
 #include "../../CoreModules/GestureRecognitionPipeline.h"
 
+#include <functional>
+
 namespace GRT {
 
 template< class T > 


### PR DESCRIPTION
Functional header is missing in GridSearch.h and without it build fails on VS 2015