### PR TITLE
Added static method removeObserver to all log classes

### DIFF
--- a/GRT/Util/DebugLog.cpp
+++ b/GRT/Util/DebugLog.cpp
@@ -37,7 +37,7 @@ bool DebugLog::registerObserver(Observer< DebugLogMessage > &observer){
 
 bool DebugLog::removeObserver(Observer< DebugLogMessage > &observer)
 {
-	return observerManager.removeObserver(observer);
+    return observerManager.removeObserver(observer);
 }
 
 } //End of namespace GRT

--- a/GRT/Util/DebugLog.cpp
+++ b/GRT/Util/DebugLog.cpp
@@ -35,4 +35,9 @@ bool DebugLog::registerObserver(Observer< DebugLogMessage > &observer){
     return true;
 }
 
+bool DebugLog::removeObserver(Observer< DebugLogMessage > &observer)
+{
+	return observerManager.removeObserver(observer);
+}
+
 } //End of namespace GRT

--- a/GRT/Util/DebugLog.h
+++ b/GRT/Util/DebugLog.h
@@ -71,6 +71,8 @@ public:
     static bool enableLogging(bool loggingEnabled);
 
     static bool registerObserver(Observer< DebugLogMessage > &observer);
+
+	static bool removeObserver(Observer< DebugLogMessage > &observer);
     
 protected:
     virtual void triggerCallback( const std::string &message ) const{

--- a/GRT/Util/DebugLog.h
+++ b/GRT/Util/DebugLog.h
@@ -72,7 +72,7 @@ public:
 
     static bool registerObserver(Observer< DebugLogMessage > &observer);
 
-	static bool removeObserver(Observer< DebugLogMessage > &observer);
+    static bool removeObserver(Observer< DebugLogMessage > &observer);
     
 protected:
     virtual void triggerCallback( const std::string &message ) const{

--- a/GRT/Util/ErrorLog.cpp
+++ b/GRT/Util/ErrorLog.cpp
@@ -35,4 +35,9 @@ bool ErrorLog::registerObserver(Observer< ErrorLogMessage > &observer){
     return true;
 }
 
+bool ErrorLog::removeObserver(Observer< ErrorLogMessage > &observer)
+{
+	return observerManager.removeObserver(observer);
+}
+
 } //End of namespace GRT

--- a/GRT/Util/ErrorLog.cpp
+++ b/GRT/Util/ErrorLog.cpp
@@ -37,7 +37,7 @@ bool ErrorLog::registerObserver(Observer< ErrorLogMessage > &observer){
 
 bool ErrorLog::removeObserver(Observer< ErrorLogMessage > &observer)
 {
-	return observerManager.removeObserver(observer);
+    return observerManager.removeObserver(observer);
 }
 
 } //End of namespace GRT

--- a/GRT/Util/ErrorLog.h
+++ b/GRT/Util/ErrorLog.h
@@ -75,6 +75,8 @@ public:
     static bool enableLogging(bool loggingEnabled);
     
     static bool registerObserver(Observer< ErrorLogMessage > &observer);
+
+	static bool removeObserver(Observer< ErrorLogMessage > &observer);
     
 protected:
     virtual void triggerCallback( const std::string &message ) const{

--- a/GRT/Util/ErrorLog.h
+++ b/GRT/Util/ErrorLog.h
@@ -76,7 +76,7 @@ public:
     
     static bool registerObserver(Observer< ErrorLogMessage > &observer);
 
-	static bool removeObserver(Observer< ErrorLogMessage > &observer);
+    static bool removeObserver(Observer< ErrorLogMessage > &observer);
     
 protected:
     virtual void triggerCallback( const std::string &message ) const{

--- a/GRT/Util/InfoLog.cpp
+++ b/GRT/Util/InfoLog.cpp
@@ -35,4 +35,9 @@ bool InfoLog::registerObserver(Observer< InfoLogMessage > &observer){
     return true;
 }
 
+bool InfoLog::removeObserver(Observer< InfoLogMessage > &observer)
+{
+	return observerManager.removeObserver(observer);
+}
+
 } //End of namespace GRT

--- a/GRT/Util/InfoLog.cpp
+++ b/GRT/Util/InfoLog.cpp
@@ -37,7 +37,7 @@ bool InfoLog::registerObserver(Observer< InfoLogMessage > &observer){
 
 bool InfoLog::removeObserver(Observer< InfoLogMessage > &observer)
 {
-	return observerManager.removeObserver(observer);
+    return observerManager.removeObserver(observer);
 }
 
 } //End of namespace GRT

--- a/GRT/Util/InfoLog.h
+++ b/GRT/Util/InfoLog.h
@@ -72,7 +72,7 @@ public:
     
     static bool registerObserver(Observer< InfoLogMessage > &observer);
 
-	static bool removeObserver(Observer< InfoLogMessage > &observer);
+    static bool removeObserver(Observer< InfoLogMessage > &observer);
 
 protected:
     virtual void triggerCallback( const std::string &message ) const{

--- a/GRT/Util/InfoLog.h
+++ b/GRT/Util/InfoLog.h
@@ -72,6 +72,8 @@ public:
     
     static bool registerObserver(Observer< InfoLogMessage > &observer);
 
+	static bool removeObserver(Observer< InfoLogMessage > &observer);
+
 protected:
     virtual void triggerCallback( const std::string &message ) const{
         observerManager.notifyObservers( InfoLogMessage(proceedingText,message) );

--- a/GRT/Util/TestingLog.cpp
+++ b/GRT/Util/TestingLog.cpp
@@ -35,4 +35,9 @@ bool TestingLog::registerObserver(Observer< TestingLogMessage > &observer){
     return true;
 }
 
+bool TestingLog::removeObserver(Observer< TestingLogMessage > &observer)
+{
+	return observerManager.removeObserver(observer);
+}
+
 } //End of namespace GRT

--- a/GRT/Util/TestingLog.cpp
+++ b/GRT/Util/TestingLog.cpp
@@ -37,7 +37,7 @@ bool TestingLog::registerObserver(Observer< TestingLogMessage > &observer){
 
 bool TestingLog::removeObserver(Observer< TestingLogMessage > &observer)
 {
-	return observerManager.removeObserver(observer);
+    return observerManager.removeObserver(observer);
 }
 
 } //End of namespace GRT

--- a/GRT/Util/TestingLog.h
+++ b/GRT/Util/TestingLog.h
@@ -73,6 +73,8 @@ public:
     static bool enableLogging(bool loggingEnabled);
     
     static bool registerObserver(Observer< TestingLogMessage > &observer);
+
+	static bool removeObserver(Observer< TestingLogMessage > &observer);
     
 protected:
     virtual void triggerCallback( const std::string &message ) const{

--- a/GRT/Util/TestingLog.h
+++ b/GRT/Util/TestingLog.h
@@ -74,7 +74,7 @@ public:
     
     static bool registerObserver(Observer< TestingLogMessage > &observer);
 
-	static bool removeObserver(Observer< TestingLogMessage > &observer);
+    static bool removeObserver(Observer< TestingLogMessage > &observer);
     
 protected:
     virtual void triggerCallback( const std::string &message ) const{

--- a/GRT/Util/TrainingLog.cpp
+++ b/GRT/Util/TrainingLog.cpp
@@ -35,4 +35,9 @@ bool TrainingLog::registerObserver(Observer< TrainingLogMessage > &observer){
     return true;
 }
 
+bool TrainingLog::removeObserver(Observer< TrainingLogMessage > &observer)
+{
+	return observerManager.removeObserver(observer);
+}
+
 }; //End of namespace GRT

--- a/GRT/Util/TrainingLog.cpp
+++ b/GRT/Util/TrainingLog.cpp
@@ -37,7 +37,7 @@ bool TrainingLog::registerObserver(Observer< TrainingLogMessage > &observer){
 
 bool TrainingLog::removeObserver(Observer< TrainingLogMessage > &observer)
 {
-	return observerManager.removeObserver(observer);
+    return observerManager.removeObserver(observer);
 }
 
 }; //End of namespace GRT

--- a/GRT/Util/TrainingLog.h
+++ b/GRT/Util/TrainingLog.h
@@ -73,6 +73,8 @@ public:
     static bool enableLogging(bool loggingEnabled);
     
     static bool registerObserver(Observer< TrainingLogMessage > &observer);
+
+	static bool removeObserver(Observer< TrainingLogMessage > &observer);
     
 protected:
     virtual void triggerCallback( const std::string &message ) const{

--- a/GRT/Util/TrainingLog.h
+++ b/GRT/Util/TrainingLog.h
@@ -74,7 +74,7 @@ public:
     
     static bool registerObserver(Observer< TrainingLogMessage > &observer);
 
-	static bool removeObserver(Observer< TrainingLogMessage > &observer);
+    static bool removeObserver(Observer< TrainingLogMessage > &observer);
     
 protected:
     virtual void triggerCallback( const std::string &message ) const{

--- a/GRT/Util/WarningLog.cpp
+++ b/GRT/Util/WarningLog.cpp
@@ -37,7 +37,7 @@ bool WarningLog::registerObserver(Observer< WarningLogMessage > &observer){
 
 bool WarningLog::removeObserver(Observer< WarningLogMessage > &observer)
 {
-	return observerManager.removeObserver(observer);
+    return observerManager.removeObserver(observer);
 }
 
 } //End of namespace GRT

--- a/GRT/Util/WarningLog.cpp
+++ b/GRT/Util/WarningLog.cpp
@@ -35,4 +35,9 @@ bool WarningLog::registerObserver(Observer< WarningLogMessage > &observer){
     return true;
 }
 
+bool WarningLog::removeObserver(Observer< WarningLogMessage > &observer)
+{
+	return observerManager.removeObserver(observer);
+}
+
 } //End of namespace GRT

--- a/GRT/Util/WarningLog.h
+++ b/GRT/Util/WarningLog.h
@@ -77,6 +77,8 @@ public:
     
     static bool registerObserver(Observer< WarningLogMessage > &observer);
     
+	static bool removeObserver(Observer< WarningLogMessage > &observer);
+
 protected:
     virtual void triggerCallback( const std::string &message ) const{
         observerManager.notifyObservers( WarningLogMessage(proceedingText,message) );

--- a/GRT/Util/WarningLog.h
+++ b/GRT/Util/WarningLog.h
@@ -77,7 +77,7 @@ public:
     
     static bool registerObserver(Observer< WarningLogMessage > &observer);
     
-	static bool removeObserver(Observer< WarningLogMessage > &observer);
+    static bool removeObserver(Observer< WarningLogMessage > &observer);
 
 protected:
     virtual void triggerCallback( const std::string &message ) const{


### PR DESCRIPTION
Those methods were obviously missing.

Therefore, it was not possible to remove observers once registered, which caused some problems if those observers were destroyed for some reason or another.