### PR TITLE
Fixed class likelihood computation in DTW to avoid division by 0

### DIFF
--- a/GRT/ClassificationModules/DTW/DTW.cpp
+++ b/GRT/ClassificationModules/DTW/DTW.cpp
@@ -410,7 +410,16 @@ bool DTW::predict_(MatrixDouble &inputTimeSeries){
 	for(UINT k=0; k<numTemplates; k++){
 		//Perform DTW
 		classDistances[k] = computeDistance(templatesBuffer[k].timeSeries,*timeSeriesPtr,distanceMatrices[k],warpPaths[k]);
-        classLikelihoods[k] = 1.0 / classDistances[k];
+        
+		if(classDistances[k] > 1e-9)
+		{
+			classLikelihoods[k] = 1.0 / classDistances[k];
+		}
+		else
+		{
+			classLikelihoods[k] = 1e9;
+		}
+
         sum += classLikelihoods[k];
 	}
 


### PR DESCRIPTION
In case when the tested data is the same as one of the templates selected by DTW (either because of low resolution input data or too much smoothing), the computed distance is 0 and the class likelihood is therefore undefined.

A solution could have been to manually detect 0 distances to force likelihood to 1 and 0 for other classes, but I think this solution is more generic and robust. If more than one computed distance is 0 (should never happen normally), the class likelihood will still be computed correctly.

I set the min possible distance threshold to 1e-9 arbitrarily based on the accuracy of double precision variables. I'm not sure it's the best possible value but it's working fine for me.