### PR TITLE
Bug fixes

### DIFF
--- a/GRT/ClassificationModules/HMM/ContinuousHiddenMarkovModel.cpp
+++ b/GRT/ClassificationModules/HMM/ContinuousHiddenMarkovModel.cpp
@@ -239,7 +239,7 @@ bool ContinuousHiddenMarkovModel::train_(TimeSeriesClassificationSample &trainin
 
     //The number of states is simply set as the number of samples in the training sample
     timeseriesLength = trainingData.getLength();
-    numStates = (unsigned int)floor(timeseriesLength/downsampleFactor);
+    numStates = (unsigned int)floor((double)(timeseriesLength/downsampleFactor));
     numInputDimensions = trainingData.getNumDimensions();
     classLabel = trainingData.getClassLabel();
     

--- a/GRT/DataStructures/Vector.h
+++ b/GRT/DataStructures/Vector.h
@@ -115,7 +115,7 @@ public:
     */
     Vector& operator=(const std::vector< T > &rhs){
         if(this!=&rhs){
-            unsigned int N = rhs.getSize();
+            unsigned int N = rhs.size();
             if( N > 0 ){
                 this->resize( N );
                 std::copy( rhs.begin(), rhs.end(), this->begin() );

--- a/GRT/Util/GRTTypedefs.h
+++ b/GRT/Util/GRTTypedefs.h
@@ -194,6 +194,16 @@ typedef unsigned long ULONG;
 /**
   @brief custom GRT assert function
 */
+#if defined(_MSC_VER) && _MSC_VER <= 1800
+//Use __FUNCTION__ instead of __func__ for Visual Studio 2013 & earlier
+#define grt_assert(x) \
+do { \
+if (0 == (x)) { \
+fprintf(stderr, "Assertion failed: %s, %s(), %d at \'%s\'\n", __FILENAME__, __FUNCTION__, __LINE__, grt_to_str(x) ); \
+abort(); \
+} \
+} while (0)
+#else // _MSC_VER <= 1800
 #define grt_assert(x) \
 do { \
 if (0 == (x)) { \
@@ -201,9 +211,10 @@ fprintf(stderr, "Assertion failed: %s, %s(), %d at \'%s\'\n", __FILENAME__, __fu
 abort(); \
 } \
 } while (0)
-#else
+#endif // _MSC_VER <= 1800
+#else // !NDEBUG
 #define grt_assert(x)
-#endif
+#endif // !NDEBUG
     
 //Declare typedefs for the legacy data types
 class ClassificationData;


### PR DESCRIPTION
Here are some things I found while trying to get GRT to build under Visual Studio 2010-2013.

1) Use __FUNCTION__ instead of __func__ for Visual Studio 2013 & earlier.
2) Use size() with std::vector<>.
3) Resolve ambiguous use of floor().