### PR TITLE
Adding getRegisteredRegressifiers method to the Regressifier class

### DIFF
--- a/GRT/CoreModules/Regressifier.cpp
+++ b/GRT/CoreModules/Regressifier.cpp
@@ -69,6 +69,17 @@ Regressifier::~Regressifier(void){
         stringRegressifierMap = NULL;
     }
 }
+
+Vector< std::string > Regressifier::getRegisteredRegressifiers(){
+    Vector< std::string > registeredRegressifiers;
+    
+    StringRegressifierMap::iterator iter = getMap()->begin();
+    while( iter != getMap()->end() ){
+        registeredRegressifiers.push_back( iter->first );
+        ++iter; //++iter is faster than iter++ as it does not require a copy/move operator
+    }
+    return registeredRegressifiers;
+}
     
 bool Regressifier::copyBaseVariables(const Regressifier *regressifier){
     


### PR DESCRIPTION
There was an error in building the `RegressifierTest`, as the `getRegisteredRegressifiers` was not implemented in the `Regressifier` class. I added in that method, based off of the `getRegisteredClassifiers` method in the `Classifier` class. The `RegressifierTest` now builds and passes properly. 