### PR TITLE
Add enum guard to SVMType and KernelType

### DIFF
--- a/GRT/ClassificationModules/SVM/SVM.h
+++ b/GRT/ClassificationModules/SVM/SVM.h
@@ -46,8 +46,8 @@ the KNN, GMM or ANBC algorithms) might not be able to solve.
 */
 class GRT_API SVM : public Classifier{
 public:
-    enum SVMType{ C_SVC = 0, NU_SVC, ONE_CLASS, EPSILON_SVR, NU_SVR };
-    enum KernelType{ LINEAR_KERNEL = 0, POLY_KERNEL, RBF_KERNEL, SIGMOID_KERNEL, PRECOMPUTED_KERNEL };
+    enum SVMType{ C_SVC = 0, NU_SVC, ONE_CLASS, EPSILON_SVR, NU_SVR, NUM_SVM_TYPES };
+    enum KernelType{ LINEAR_KERNEL = 0, POLY_KERNEL, RBF_KERNEL, SIGMOID_KERNEL, PRECOMPUTED_KERNEL, NUM_KERNEL_TYPES };
 
     /**
      Default constructor.


### PR DESCRIPTION
This is consistent with other classes in GRT that have enum guards for "types" and helps wrapper code to verify types are in range, e.g. when casting from int to the respective enum type.