### PR TITLE
DTW fix

### DIFF
--- a/GRT/ClassificationModules/DTW/DTW.cpp
+++ b/GRT/ClassificationModules/DTW/DTW.cpp
@@ -715,7 +715,7 @@ Float DTW::d(int m,int n,MatrixFloat &distanceMatrix,const int M,const int N){
     
     //If this cell contains a negative value then it has already been searched
     //The cost is therefore the absolute value of the negative value so return it
-    if( distanceMatrix[m][n] < 0 ){
+    if( std::signbit(distanceMatrix[m][n]) ){
         dist = fabs( distanceMatrix[m][n] );
         return dist;
     }


### PR DESCRIPTION
Simple fix for DTW to reduce prediction time.

I stumbled on one edge case that made predictions for DTW potentially take hours because the dynamic programming approach was not working as expected. Indeed, when paths in the distance matrix append to have a cost of zero, the cost of the path would be recomputed every time, independently of the sign of the value (-0 < 0 is always false).

This lead in my case to re-computation of the end path every time, i.e. millions of time, which basically froze the application.

Instead of doing a simple inferior test, the proposed fix leverage the standard signbit function to test the actual sign of the value, even if the value is equal to zero, therefore fixing the dynamic programming approach.