### PR TITLE
Allow a VectorFloat to be initialised from a vector<Float>

### DIFF
--- a/GRT/DataStructures/VectorFloat.cpp
+++ b/GRT/DataStructures/VectorFloat.cpp
@@ -40,6 +40,13 @@ VectorFloat::VectorFloat(const size_type size, const Float &value){
   errorLog.setKey("[ERROR VectorFloat]");
   resize(size, value);
 }
+
+VectorFloat::VectorFloat(const std::vector<Float>& values){
+  warningLog.setKey("[WARNING VectorFloat]");
+  errorLog.setKey("[ERROR VectorFloat]");
+  *this = Vector<Float>(values);
+}
+
     
 VectorFloat::VectorFloat(const VectorFloat &rhs):Vector(rhs){
   warningLog.setKey("[WARNING VectorFloat]");

--- a/GRT/DataStructures/VectorFloat.h
+++ b/GRT/DataStructures/VectorFloat.h
@@ -53,6 +53,13 @@ public:
     GRT_API VectorFloat( const std::vector<Float>::size_type size, const Float &value );
     
     /**
+     Constructor, initializes the VectorFloat from a std::vector<Float>
+     
+     @param value: the values that will be written to all elements in the vector
+     */
+    GRT_API VectorFloat( const std::vector<Float>& values );
+
+    /**
      Copy Constructor, copies the values from the rhs VectorFloat to this VectorFloat instance
      
      @param rhs: the VectorFloat from which the values will be copied


### PR DESCRIPTION
This allows for more convenient inline adding of feature vectors, for example:

```
ClassificationData data;

data.addSample(1, vector<Float>{1, 2, 3, 4, 5});
```